### PR TITLE
Refactor: Clarify iCal URL usage and update documentation

### DIFF
--- a/download-flyer.php
+++ b/download-flyer.php
@@ -5,7 +5,8 @@
 
 // --- ACTION REQUIRED ---
 // Paste your private Nextcloud iCal subscription URL here.
-$ical_url = 'https://cloud.outfrontyouth.org/remote.php/dav/public-calendars/o4BqHRSHaDJjiqjs?export'; // <-- PASTE YOUR URL HERE
+// IMPORTANT: Please verify this is the correct and active iCal URL.
+$ical_url = 'https://cloud.outfrontyouth.org/remote.php/dav/public-calendars/o4BqHRSHaDJjiqjs?export';
 
 
 // --- No need to edit below this line ---

--- a/generate-flyer-image.php
+++ b/generate-flyer-image.php
@@ -88,7 +88,6 @@ try {
     echo "Error during PNG generation: " . htmlspecialchars($e->getMessage());
     // If $e is an ImagickException, it might have more specific details,
     // but the main message from getMessage() is usually sufficient.
-    // No standard 'get μπορούσενα' method exists.
     exit;
 }
 

--- a/generate-post-image.php
+++ b/generate-post-image.php
@@ -4,7 +4,8 @@
 
 // --- ACTION REQUIRED ---
 // Paste your private Nextcloud iCal subscription URL here.
-$ical_url = 'https://cloud.outfrontyouth.org/remote.php/dav/public-calendars/o4BqHRSHaDJjiqjs?export'; // <-- PASTE YOUR URL HERE
+// IMPORTANT: Please verify this is the correct and active iCal URL.
+$ical_url = 'https://cloud.outfrontyouth.org/remote.php/dav/public-calendars/o4BqHRSHaDJjiqjs?export';
 
 // --- FONT CONFIGURATION ---
 // IMPORTANT: You must have a TrueType Font (.ttf) file for this to work.

--- a/image-generator-ui.php
+++ b/image-generator-ui.php
@@ -3,7 +3,8 @@
 
 // --- ACTION REQUIRED ---
 // Paste your private Nextcloud iCal subscription URL here.
-$ical_url = 'https://cloud.outfrontyouth.org/remote.php/dav/public-calendars/o4BqHRSHaDJjiqjs?export'; // <-- PASTE YOUR URL HERE
+// IMPORTANT: Please verify this is the correct and active iCal URL.
+$ical_url = 'https://cloud.outfrontyouth.org/remote.php/dav/public-calendars/o4BqHRSHaDJjiqjs?export';
 
 // --- Data Fetching and Parsing (Copied from your image generator script) ---
 require_once('calendar-functions.php');

--- a/readme.md
+++ b/readme.md
@@ -83,10 +83,12 @@ All event information for both the interactive web calendar and the downloadable
 *   **To add an event:** Simply create a new event in your Nextcloud calendar that is public or shared on the calendar feed.
 *   **To edit or remove an event:** Just edit or delete the event in Nextcloud.
 
-If you ever need to change the source iCalendar feed itself (e.g., if the Nextcloud calendar URL changes):
-1.  Open **`download-flyer.php`**.
-2.  Find the `$ical_url` variable near the top of the file.
-3.  Replace the existing URL with your new public iCal subscription link.
+If you ever need to change the source iCalendar feed itself (e.g., if the Nextcloud calendar URL changes), you'll need to update it in a few places:
+*   **`download-flyer.php`**: Find the `$ical_url` variable near the top. This URL is used for both PDF flyer generation and for providing JSON event data to the `index.html` calendar.
+*   **`generate-post-image.php`**: Find the `$ical_url` variable near the top. This is used for generating single event post images.
+*   **`image-generator-ui.php`**: Find the `$ical_url` variable near the top. This is used by the UI to list events for image generation.
+
+Remember to use your private Nextcloud iCal subscription link.
 
 ---
 
@@ -100,7 +102,7 @@ The main page (`index.html`) features an interactive calendar:
 *   **Navigation:** Users can move to the previous or next month.
 *   **Event Indicators:** Days with events are highlighted.
 *   **Event Details Modal:** Clicking on a day with events opens a pop-up window showing details for each event on that day (summary, time, location, description).
-*   **Data Source:** Event data is fetched dynamically from `download-flyer.php` (which in turn gets it from your Nextcloud calendar).
+*   **Data Source:** Event data is fetched dynamically by `index.html` by calling `download-flyer.php?json=true`. The `download-flyer.php` script, in turn, uses its defined `$ical_url` to get events from your Nextcloud calendar via `calendar-functions.php`.
 
 #### **B. PDF Event Flyer Generation**
 
@@ -113,7 +115,7 @@ The website can generate a downloadable PDF flyer for any given month's events:
 *   **Logo Choice (New!):** The interactive calendar on `index.html` has a "Use Color Logo on Flyer" checkbox.
     *   If checked, the PDF flyer will use the color `outfront-logo.png`.
     *   If unchecked (default), it will use the `outfront-logo-bw.png`.
-*   **Source:** Event data is pulled from the Nextcloud calendar via the `$ical_url` in `download-flyer.php`.
+*   **Source:** Event data is pulled from the Nextcloud calendar. The `download-flyer.php` script uses its defined `$ical_url` and the `calendar-functions.php` helper script to fetch this data.
 
 #### **C. Image Generation Tools**
 


### PR DESCRIPTION
- Updated comments in `download-flyer.php`, `generate-post-image.php`, and `image-generator-ui.php` to emphasize verification of the private iCal URL.
- Confirmed that `download-flyer.php` correctly uses its existing `$ical_url` for JSON event data for the website calendar.
- Reviewed and confirmed that the commented-out title in Template 2 of `generate-post-image.php` is an intentional design choice.
- Updated `readme.md` to accurately reflect iCal URL update procedures and data flow for calendar functions.
- Removed a minor non-standard comment from `generate-flyer-image.php`.